### PR TITLE
Tokenize rewrite

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1,86 +1,5 @@
 const std = @import("std");
-
-const Keyword = enum {
-    _int,
-    _void,
-    _char,
-    _return,
-};
-
-const Punctuation = enum {
-    _open_parenthesis,
-    _close_parenthesis,
-    _open_brace,
-    _close_brace,
-    _semicolon,
-};
-
-const Constant = struct { kind: enum { int_val, float_val, char_val, string_val }, value: union {
-    int_val: i32,
-    float_val: f32,
-    char_val: u8,
-    string_val: []const u8,
-} };
-
-const Token = union(enum) {
-    _keyword: Keyword,
-    _punctuation: Punctuation,
-    _constant: Constant,
-    _identifier: []const u8,
-};
-
-const Program = struct {
-    functions: []Function,
-};
-
-const Function = struct {
-    function_name: []const u8,
-    function_body: Statement,
-};
-
-const Statement = union(enum) {
-    return_stmt: Return,
-    expression_stmt: Expression,
-};
-
-const Expression = union(enum) {
-    constant_expr: Constant,
-    // identifier: Identifier,
-    // operation: Operation,
-};
-
-const Return = struct {
-    return_value: Expression, // for now, only constants are supported
-};
-
-const Parser = struct {
-    tokens: []Token,
-    current_token: usize,
-    allocator: std.mem.Allocator,
-
-    pub fn init(tokens: []Token, allocator: std.mem.Allocator) Parser {
-        return Parser{ .tokens = tokens, .current_token = 0, .allocator = allocator };
-    }
-
-    fn peek(self: *Parser) ?Token {
-        if (self.current_token + 1 >= self.tokens.len) return null;
-        return self.tokens[self.current_token];
-    }
-
-    fn consume(self: *Parser) Token {
-        return self.tokens[self.current_token + 1];
-    }
-
-    fn match(self: *Parser, tag: Token) bool {
-        if (self.peek()) |token| {
-            if (std.meta.activeTag(token) == tag) {
-                self.current_token += 1;
-                return true;
-            }
-        }
-        return false;
-    }
-};
+const Tokenizer = @import("tokenizer.zig").Tokenizer;
 
 pub fn main() !void {
     const args = try std.process.argsAlloc(std.heap.page_allocator);
@@ -99,110 +18,34 @@ pub fn main() !void {
         return;
     }
 
-    const file = std.fs.cwd().openFile(args[1], .{}) catch |err| {
-        std.log.err("Failed to open file: {s}", .{@errorName(err)});
-        return;
-    };
+    const file_path = args[1];
+    var tokenizer = try Tokenizer.init(allocator, file_path);
+    defer tokenizer.deinit();
 
-    defer file.close();
-    var buffer = std.ArrayList(u8).init(allocator);
-    var tokens = std.ArrayList(Token).init(allocator);
-    defer buffer.deinit();
-    defer tokens.deinit();
-
-    while (file.reader().readUntilDelimiterOrEofAlloc(allocator, '\n', 1024) catch |err| {
-        std.log.err("Failed to read line: {s}", .{@errorName(err)});
-        return;
-    }) |line| {
-        defer allocator.free(line);
-        var index: usize = 0;
-        std.debug.print("{s}\n", .{line});
-        while (index < line.len) {
-            const cur_char = line[index];
-            if (std.ascii.isAlphabetic(cur_char)) { // if it is a keyword or identifier then go ahead
-                try buffer.append(cur_char);
-                index += 1;
-                while (index < line.len and std.ascii.isAlphanumeric(line[index])) { // gets the entire 'word'
-                    try buffer.append(line[index]);
-                    index += 1;
-                }
-                index -= 1;
-                // detecting what kind of token it is
-                // std.debug.print("{s}", .{buffer.items});
-                if (std.mem.eql(u8, buffer.items, "int")) {
-                    try tokens.append(Token{ ._keyword = Keyword._int });
-                    buffer.clearRetainingCapacity();
-                } else if (std.mem.eql(u8, buffer.items, "void")) {
-                    try tokens.append(Token{ ._keyword = Keyword._void });
-                    buffer.clearRetainingCapacity();
-                } else if (std.mem.eql(u8, buffer.items, "return")) {
-                    try tokens.append(Token{ ._keyword = Keyword._return });
-                    buffer.clearRetainingCapacity();
-                } else { // if not a keyword, then it is a identifier
-
-                    index += 1;
-                    // std.debug.print("\n", .{});
-                    // std.debug.print("{s}\n", .{buffer.items});
-                    while (index < line.len and (std.ascii.isAlphanumeric(line[index]) or line[index] == '_')) { // gets the entire 'word'
-                        try buffer.append(line[index]);
-                        index += 1;
-                    }
-                    index -= 1;
-                    const identifier = try allocator.dupe(u8, buffer.items);
-
-                    try tokens.append(Token{ ._identifier = identifier });
-                    buffer.clearRetainingCapacity();
-                }
-                buffer.clearRetainingCapacity();
-            } else if (std.ascii.isWhitespace(cur_char)) {} else if (std.ascii.isDigit(cur_char)) {
-                var temp_int = cur_char - '0';
-                while (std.ascii.isDigit(line[index + 1])) {
-                    temp_int *= 10;
-                    temp_int += (line[index + 1] - '0');
-                    index += 1;
-                }
-                try tokens.append(Token{ ._constant = Constant{ .kind = .int_val, .value = .{ .int_val = temp_int } } });
-                buffer.clearRetainingCapacity();
-            } else if (cur_char == ';') {
-                try tokens.append(Token{ ._punctuation = Punctuation._semicolon });
-                buffer.clearRetainingCapacity();
-            } else if (cur_char == '(') {
-                try tokens.append(Token{ ._punctuation = Punctuation._open_parenthesis });
-                buffer.clearRetainingCapacity();
-            } else if (cur_char == ')') {
-                try tokens.append(Token{ ._punctuation = Punctuation._close_parenthesis });
-                buffer.clearRetainingCapacity();
-            } else if (cur_char == '{') {
-                try tokens.append(Token{ ._punctuation = Punctuation._open_brace });
-                buffer.clearRetainingCapacity();
-            } else if (cur_char == '}') {
-                try tokens.append(Token{ ._punctuation = Punctuation._close_brace });
-                buffer.clearRetainingCapacity();
-            } else {
-                std.log.err("Invalid token {s}", .{buffer.items});
-            }
-            index += 1;
+    const tokens = try tokenizer.tokenize();
+    defer {
+        for (tokens) |token| {
+            token.deinit(allocator);
         }
+        allocator.free(tokens);
     }
 
-    while (tokens.items.len > 0) {
-        const token = tokens.orderedRemove(0);
-        // std.debug.print("{any}\n", .{token});
-
+    std.debug.print("Found {} tokens:\n", .{tokens.len});
+    for (tokens, 0..) |token, i| {
+        std.debug.print("Token {}: ", .{i});
         switch (token) {
-            ._constant => {
-                std.debug.print("Constant: {any}\n", .{token._constant});
+            ._keyword => |keyword| std.debug.print("Keyword: {}\n", .{keyword}),
+            ._punctuation => |punct| std.debug.print("Punctuation: {}\n", .{punct}),
+            ._constant => |constant| {
+                std.debug.print("Constant: ", .{});
+                switch (constant.kind) {
+                    .int_val => std.debug.print("Int({})\n", .{constant.value.int_val}),
+                    .float_val => std.debug.print("Float({})\n", .{constant.value.float_val}),
+                    .char_val => std.debug.print("Char('{c}')\n", .{constant.value.char_val}),
+                    .string_val => std.debug.print("String(\"{s}\")\n", .{constant.value.string_val}),
+                }
             },
-            ._identifier => {
-                std.debug.print("Identifier: {s}\n", .{token._identifier});
-                allocator.free(token._identifier);
-            },
-            ._keyword => {
-                std.debug.print("Identifier: {any}\n", .{token._keyword});
-            },
-            ._punctuation => {
-                std.debug.print("Punctuation: {any}\n", .{token._punctuation});
-            },
+            ._identifier => |id| std.debug.print("Identifier: \"{s}\"\n", .{id}),
         }
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -56,9 +56,10 @@ const Return = struct {
 const Parser = struct {
     tokens: []Token,
     current_token: usize,
+    allocator: std.mem.Allocator,
 
-    pub fn init(tokens: []Token) Parser {
-        return Parser{ .tokens = tokens, .current_token = 0 };
+    pub fn init(tokens: []Token, allocator: std.mem.Allocator) Parser {
+        return Parser{ .tokens = tokens, .current_token = 0, .allocator = allocator };
     }
 
     fn peek(self: *Parser) ?Token {
@@ -66,8 +67,18 @@ const Parser = struct {
         return self.tokens[self.current_token];
     }
 
-    fn consume(self: *Parser) ?Token {
+    fn consume(self: *Parser) Token {
         return self.tokens[self.current_token + 1];
+    }
+
+    fn match(self: *Parser, tag: Token) bool {
+        if (self.peek()) |token| {
+            if (std.meta.activeTag(token) == tag) {
+                self.current_token += 1;
+                return true;
+            }
+        }
+        return false;
     }
 };
 

--- a/src/tokenizer.zig
+++ b/src/tokenizer.zig
@@ -1,0 +1,169 @@
+const std = @import("std");
+
+const Keyword = enum {
+    _int,
+    _void,
+    _char,
+    _return,
+};
+
+const Punctuation = enum {
+    _open_parenthesis,
+    _close_parenthesis,
+    _open_brace,
+    _close_brace,
+    _semicolon,
+};
+
+const Constant = struct { kind: enum { int_val, float_val, char_val, string_val }, value: union {
+    int_val: i32,
+    float_val: f32,
+    char_val: u8,
+    string_val: []const u8,
+} };
+
+const Token = union(enum) {
+    _keyword: Keyword,
+    _punctuation: Punctuation,
+    _constant: Constant,
+    _identifier: []const u8,
+
+    pub fn deinit(self: Token, allocator: std.mem.Allocator) void {
+        switch (self) {
+            ._identifier => allocator.free(self._identifier),
+            ._constant => {
+                switch (self._constant.kind) {
+                    .int_val => {},
+                    .float_val => {},
+                    .char_val => {},
+                    .string_val => allocator.free(self._constant.value.string_val),
+                }
+            },
+            else => {},
+        }
+    }
+};
+
+const Program = struct {
+    functions: []Function,
+};
+
+const Function = struct {
+    function_name: []const u8,
+    function_body: Statement,
+};
+
+const Statement = union(enum) {
+    return_stmt: Return,
+    expression_stmt: Expression,
+};
+
+const Expression = union(enum) {
+    constant_expr: Constant,
+    // identifier: Identifier,
+    // operation: Operation,
+};
+
+const Return = struct {
+    return_value: Expression, // for now, only constants are supported
+};
+
+pub const Tokenizer = struct {
+    position: usize,
+    allocator: std.mem.Allocator,
+    content: []const u8,
+
+    pub fn init(allocator: std.mem.Allocator, file_path: []const u8) !Tokenizer {
+        const file = try std.fs.cwd().openFile(file_path, .{});
+        defer file.close();
+
+        const file_size = try file.getEndPos();
+        const content = try allocator.alloc(u8, file_size);
+
+        const bytes_read = try file.readAll(content);
+        if (bytes_read != file_size) {
+            allocator.free(content);
+            return error.IncompleteRead;
+        }
+
+        return Tokenizer{ .position = 0, .allocator = allocator, .content = content };
+    }
+
+    fn peek(self: *Tokenizer) ?u8 {
+        if (self.position >= self.content.len) return null;
+        return self.content[self.position];
+    }
+
+    fn consume(self: *Tokenizer) ?u8 {
+        if (self.position >= self.content.len) return null;
+        const char = self.content[self.position];
+        self.position += 1;
+        return char;
+    }
+
+    pub fn deinit(self: *Tokenizer) void {
+        self.allocator.free(self.content);
+    }
+
+    pub fn tokenize(self: *Tokenizer) ![]Token {
+        var buffer = std.ArrayList(u8).init(self.allocator);
+        var tokens = std.ArrayList(Token).init(self.allocator);
+
+        defer buffer.deinit();
+
+        while (self.peek() != null) {
+            if (std.ascii.isAlphabetic(self.peek().?)) {
+                try buffer.append(self.consume().?);
+                while (self.peek() != null and std.ascii.isAlphanumeric(self.peek().?)) {
+                    try buffer.append(self.consume().?);
+                }
+                if (std.mem.eql(u8, buffer.items, "int")) {
+                    try tokens.append(Token{ ._keyword = Keyword._int });
+                    buffer.clearRetainingCapacity();
+                    // add other keywords here
+                } else {
+                    while (self.peek() != null and (std.ascii.isAlphanumeric(self.peek().?) or self.peek() == '_')) {
+                        try buffer.append(self.consume().?);
+                    }
+                    const identifier = try self.allocator.dupe(u8, buffer.items);
+                    try tokens.append(Token{ ._identifier = identifier });
+                    buffer.clearRetainingCapacity();
+                }
+            } else if (std.ascii.isWhitespace(self.peek().?)) {
+                _ = self.consume().?;
+            } else if (std.ascii.isDigit(self.peek().?)) {
+                var temp_int = self.consume().? - '0';
+                while (std.ascii.isDigit(self.peek().?)) {
+                    temp_int *= 10;
+                    temp_int += (self.consume().? - '0');
+                }
+                try tokens.append(Token{ ._constant = Constant{ .kind = .int_val, .value = .{ .int_val = temp_int } } });
+                buffer.clearRetainingCapacity();
+            } else if (self.peek() == ';') {
+                try tokens.append(Token{ ._punctuation = ._semicolon });
+                _ = self.consume();
+                buffer.clearRetainingCapacity();
+            } else if (self.peek() == '(') {
+                try tokens.append(Token{ ._punctuation = ._open_parenthesis });
+                _ = self.consume();
+                buffer.clearRetainingCapacity();
+            } else if (self.peek() == ')') {
+                try tokens.append(Token{ ._punctuation = ._close_parenthesis });
+                _ = self.consume();
+                buffer.clearRetainingCapacity();
+            } else if (self.peek() == '{') {
+                try tokens.append(Token{ ._punctuation = ._open_brace });
+                _ = self.consume();
+                buffer.clearRetainingCapacity();
+            } else if (self.peek() == '}') {
+                try tokens.append(Token{ ._punctuation = ._close_brace });
+                _ = self.consume();
+                buffer.clearRetainingCapacity();
+            } else {
+                std.log.err("Invalid token {s}", .{buffer.items});
+            }
+        }
+        self.position = 0;
+        return tokens.toOwnedSlice();
+    }
+};


### PR DESCRIPTION
This pull request refactors the tokenization logic by moving it to a new `Tokenizer` module and updating the main program to use this new module. The changes aim to improve code organization and maintainability.

Refactoring and code organization:

* [`src/main.zig`](diffhunk://#diff-d924ca21d81d7d5a59eb9e10d3e2689c4c58a7e28e6ecce6a064701666f5a730L2-R2): Removed the old tokenization logic and replaced it with the new `Tokenizer` module. This involved deleting the `Keyword`, `Punctuation`, `Constant`, `Token`, `Program`, `Function`, `Statement`, `Expression`, `Return`, and `Parser` definitions, and updating the `main` function to use `Tokenizer`. [[1]](diffhunk://#diff-d924ca21d81d7d5a59eb9e10d3e2689c4c58a7e28e6ecce6a064701666f5a730L2-R2) [[2]](diffhunk://#diff-d924ca21d81d7d5a59eb9e10d3e2689c4c58a7e28e6ecce6a064701666f5a730L91-R48)

New `Tokenizer` module:

* [`src/tokenizer.zig`](diffhunk://#diff-dfd43bd95c327930e95f0bf932acfe88e73adfcd022b40b3be55f9143d1abfcbR1-R169): Created a new `Tokenizer` module that encapsulates the tokenization logic. This includes defining `Keyword`, `Punctuation`, `Constant`, `Token`, and `Tokenizer` structs, and implementing the `Tokenizer.init`, `Tokenizer.peek`, `Tokenizer.consume`, `Tokenizer.deinit`, and `Tokenizer.tokenize` methods.